### PR TITLE
Add RESTATE_AUTH_TOKEN as primary auth env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The tunnel client must be configured with the following values:
 - `RESTATE_TUNNEL_NAME`: a name representing the tunnel connection; you might use the name of the cluster in which the client runs.
 - `RESTATE_ENVIRONMENT_ID`: the ID of the environment you want to tunnel to
 - `RESTATE_SIGNING_PUBLIC_KEY`: the signing public key of your Restate Cloud environment. This allows the client to validate that incoming requests come from your environment.
-- `RESTATE_BEARER_TOKEN`: a Restate Cloud API key with the `Full` role.
+- `RESTATE_AUTH_TOKEN` (formerly `RESTATE_BEARER_TOKEN`, still accepted): a Restate Cloud API key with the `Full` role.
 - `RESTATE_CLOUD_REGION`: The id of the Restate Cloud region in which your environment runs ie `us` or `eu`.
 
 Once running, your Cloud environment can register services at urls like `https://tunnel.$RESTATE_CLOUD_REGION.restate.cloud/$UNPREFIXED_RESTATE_ENVIRONMENT_ID/$RESTATE_TUNNEL_NAME/http/your-service-dns/9080`
@@ -26,7 +26,7 @@ You only need to build these URLs yourself if you're not using the operator.
 ## Remote proxy
 In addition to exposing local services to Restate Cloud, by default the tunnel client will also serve unauthenticated ingress
 and admin endpoints from Restate Cloud on its local 8080 and 9080 ports. This behaviour can be disabled with `RESTATE_REMOTE_PROXY=false`. If left enabled, be careful to restrict access to these ports;
-access to them is equivalent to having the configured `RESTATE_BEARER_TOKEN`.
+access to them is equivalent to having the configured `RESTATE_AUTH_TOKEN`.
 
 ## Releasing
 1. Update the version in Cargo.{toml,lock} eg to 0.0.2

--- a/src/main.rs
+++ b/src/main.rs
@@ -130,7 +130,7 @@ pub async fn main() -> anyhow::Result<()> {
 
     let authorization = {
         let authorization: &'static str =
-            Box::leak(Box::<str>::from(format!("Bearer {}", options.bearer_token)));
+            Box::leak(Box::<str>::from(format!("Bearer {}", options.auth_token)));
         let mut authorization = http::HeaderValue::from_static(authorization);
         authorization.set_sensitive(true);
         authorization
@@ -282,7 +282,7 @@ pub async fn main() -> anyhow::Result<()> {
                 }),
                 &options.environment_id,
                 &options.signing_public_key,
-                &options.bearer_token,
+                &options.auth_token,
                 Some(options.tunnel_name.clone()),
                 Option::<fn(_)>::None,
             )

--- a/src/options.rs
+++ b/src/options.rs
@@ -32,8 +32,10 @@ struct OptionsShadow {
     tunnel_servers: Option<HashSet<Uri>>,
     #[serde_as(as = "Option<serde_with::DisplayFromStr>")]
     tunnel_servers_srv: Option<hickory_resolver::Name>,
-    bearer_token: Option<String>,
-    bearer_token_file: Option<PathBuf>,
+    #[serde(alias = "bearer-token", skip_serializing_if = "Option::is_none")]
+    auth_token: Option<String>,
+    #[serde(alias = "bearer-token-file", skip_serializing_if = "Option::is_none")]
+    auth_token_file: Option<PathBuf>,
     connect_timeout: Duration,
     pools_per_tunnel: NonZeroUsize,
     initial_max_send_streams: Option<usize>,
@@ -63,8 +65,8 @@ impl Default for OptionsShadow {
             tunnel_name: None,
             tunnel_servers: None,
             tunnel_servers_srv: None,
-            bearer_token: None,
-            bearer_token_file: None,
+            auth_token: None,
+            auth_token_file: None,
             connect_timeout: Duration::from_secs(5),
             pools_per_tunnel: NonZeroUsize::new(16).unwrap(),
             initial_max_send_streams: None,
@@ -101,7 +103,7 @@ impl Default for OptionsShadow {
 pub struct Options {
     pub environment_id: String,
     pub signing_public_key: String,
-    pub bearer_token: String,
+    pub auth_token: String,
 
     pub tunnel_name: String,
     pub tunnel_servers: BoxStream<'static, HashMap<Uri, ServerName>>,
@@ -129,6 +131,21 @@ impl Options {
         // Load configuration file
         figment = figment.merge(Toml::file(path));
 
+        if std::env::var_os("RESTATE_AUTH_TOKEN").is_some()
+            && std::env::var_os("RESTATE_BEARER_TOKEN").is_some()
+        {
+            bail!(
+                "Both RESTATE_AUTH_TOKEN and RESTATE_BEARER_TOKEN are set; unset RESTATE_BEARER_TOKEN (deprecated alias for RESTATE_AUTH_TOKEN)"
+            );
+        }
+        if std::env::var_os("RESTATE_AUTH_TOKEN_FILE").is_some()
+            && std::env::var_os("RESTATE_BEARER_TOKEN_FILE").is_some()
+        {
+            bail!(
+                "Both RESTATE_AUTH_TOKEN_FILE and RESTATE_BEARER_TOKEN_FILE are set; unset RESTATE_BEARER_TOKEN_FILE (deprecated alias for RESTATE_AUTH_TOKEN_FILE)"
+            );
+        }
+
         figment = figment.merge(
             Env::prefixed("RESTATE_")
                 .split("__")
@@ -137,23 +154,23 @@ impl Options {
 
         let shadow: OptionsShadow = figment.extract()?;
 
-        let bearer_token = match (shadow.bearer_token, shadow.bearer_token_file) {
+        let auth_token = match (shadow.auth_token, shadow.auth_token_file) {
             (None, None) => {
                 bail!(
-                    "Either 'bearer_token' (RESTATE_BEARER_TOKEN) or 'bearer_token_file' (RESTATE_BEARER_TOKEN_FILE) options must be provided"
+                    "Either 'auth_token' (RESTATE_AUTH_TOKEN) or 'auth_token_file' (RESTATE_AUTH_TOKEN_FILE) options must be provided"
                 );
             }
-            (Some(bearer_token), _) => bearer_token,
-            (None, Some(bearer_token_file)) => {
-                let mut bearer_token = tokio::fs::read_to_string(&bearer_token_file)
+            (Some(auth_token), _) => auth_token,
+            (None, Some(auth_token_file)) => {
+                let mut auth_token = tokio::fs::read_to_string(&auth_token_file)
                     .await
-                    .context("failed to read bearer token file")?;
-                bearer_token.truncate(bearer_token.trim_end().len());
+                    .context("failed to read auth token file")?;
+                auth_token.truncate(auth_token.trim_end().len());
                 info!(
-                    "Loaded initial bearer token from {}",
-                    bearer_token_file.display()
+                    "Loaded initial auth token from {}",
+                    auth_token_file.display()
                 );
-                bearer_token
+                auth_token
             }
         };
 
@@ -268,7 +285,7 @@ impl Options {
             signing_public_key,
             tunnel_name,
             tunnel_servers,
-            bearer_token,
+            auth_token,
             connect_timeout: shadow.connect_timeout,
             pools_per_tunnel: shadow.pools_per_tunnel,
             initial_max_send_streams: shadow.initial_max_send_streams,


### PR DESCRIPTION
Align the API key config variable with Restate CLI, based on customer feedback.

## Summary
- `RESTATE_AUTH_TOKEN` and `RESTATE_AUTH_TOKEN_FILE` are now the primary env vars for the Restate Cloud API token
- `RESTATE_BEARER_TOKEN` / `RESTATE_BEARER_TOKEN_FILE` continue to work as backwards-compatible aliases via serde `#[serde(alias)]`, covering both env vars and TOML config keys
- Refuse to start when both the new and legacy name for the same value are set, rather than picking one non-deterministically
- Internal field names renamed from `bearer_token` to `auth_token` for consistency

## Test plan
- [x] `cargo build` passes
- [x] `cargo test` passes (9/9)
- [x] `cargo fmt --check` passes
- [x] `cargo clippy` clean (no new warnings)
- [x] Verified end-to-end with a scratch program: `RESTATE_AUTH_TOKEN`, `RESTATE_BEARER_TOKEN`, TOML `auth-token`, and TOML `bearer-token` all deserialize into the `auth_token` field
- [x] Verified collision errors fire when both `RESTATE_AUTH_TOKEN` and `RESTATE_BEARER_TOKEN` are set