### PR TITLE
Add connection tuning knobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository manages a client intended to establish tunnelling connections from your compute infrastructure
 to your Restate Cloud environment, such that your environment can talk to Restate SDK services running in your
 private network. In addition, the client can serve on ports 8080 and 9070, providing unauthenticated access to
-your Restate Cloud environment (see 'Remote proxy' below).
+your Restate Cloud environment (see 'Environment proxy' below).
 
 The client is primarily intended to be managed in Kubernetes by the [operator](https://github.com/restatedev/restate-operator), but it is possible to run it yourself if necessary.
 
@@ -23,10 +23,29 @@ restate dep register https://tunnel.us.restate.cloud:9080/201k0yd4rz8yftmd4awh1b
 
 You only need to build these URLs yourself if you're not using the operator.
 
-## Remote proxy
+## Environment proxy
 In addition to exposing local services to Restate Cloud, by default the tunnel client will also serve unauthenticated ingress
-and admin endpoints from Restate Cloud on its local 8080 and 9080 ports. This behaviour can be disabled with `RESTATE_REMOTE_PROXY=false`. If left enabled, be careful to restrict access to these ports;
+and admin endpoints from Restate Cloud on its local 8080 and 9070 ports. This behaviour can be disabled with `RESTATE_ENVIRONMENT_PROXY=false` (`RESTATE_REMOTE_PROXY=false` is still accepted as a deprecated alias). If left enabled, be careful to restrict access to these ports;
 access to them is equivalent to having the configured `RESTATE_AUTH_TOKEN`.
+
+Do not set both `RESTATE_ENVIRONMENT_PROXY` and `RESTATE_REMOTE_PROXY`. For rollback compatibility, keep using `RESTATE_REMOTE_PROXY` until every tunnel client binary in the rollout supports `RESTATE_ENVIRONMENT_PROXY`; older binaries ignore the new name and fall back to the default of `true`.
+
+When the tunnel client is managed by the current Restate operator, use `RESTATE_REMOTE_PROXY` for this toggle. The operator emits that env var itself, so adding `RESTATE_ENVIRONMENT_PROXY` separately will make the tunnel client reject the duplicate configuration. Switching the operator to the new name requires a coordinated operator change that never emits both names and only rolls out after the tunnel client image supports `RESTATE_ENVIRONMENT_PROXY`.
+
+## Tuning
+`RESTATE_ENVIRONMENT_PROXY_CONNECTIONS` controls the number of outbound HTTP/2 connections to Restate Cloud for each local environment proxy endpoint. The default is `6`, preserving the previous hard-coded value for spreading over cloud load balancer IPs.
+
+`RESTATE_TUNNEL_SERVER_CONNECTIONS` controls how many inbound tunnel connections are opened to each resolved tunnel server. The default is `1`, preserving previous behavior. Total inbound connections are `(resolved tunnel servers) x RESTATE_TUNNEL_SERVER_CONNECTIONS`; raise `RESTATE_POOLS_PER_TUNNEL` as well when a hub needs high fan-out to a single local service.
+
+## Metrics
+The health endpoint also serves Prometheus metrics at `/metrics`. Request-level metrics include:
+
+- `restate_cloud_tunnel_requests_total{server,connection,direction,status}` for proxied request throughput.
+- `restate_cloud_tunnel_request_duration_seconds{server,connection,direction}` for time from tunnel-client request handling until upstream response headers.
+- `restate_cloud_tunnel_requests_inflight{server,connection,direction}` for request concurrency per tunnel or environment-proxy connection.
+- `restate_cloud_tunnel_local_handler_duration_seconds{instance}` and `restate_cloud_tunnel_local_handler_inflight{instance}` for local service handler latency and concurrency.
+
+Use `sum without (connection)` to aggregate per-connection tunnel metrics back to the previous per-server view.
 
 ## Releasing
 1. Update the version in Cargo.{toml,lock} eg to 0.0.2

--- a/docs/specs/2026-05-27-connection-tuning-knobs.md
+++ b/docs/specs/2026-05-27-connection-tuning-knobs.md
@@ -1,0 +1,194 @@
+# Spec: connection tuning knobs for hub deployments
+
+## Goal
+
+The operator runs the tunnel client as a centralized per-`RestateCloudEnvironment`
+Deployment (a hub shared by all `RestateDeployment`s), not a sidecar. The
+connection counts are currently hardcoded with sidecar assumptions. Expose them
+as static config so an operator (human or the k8s operator) can size a hub.
+
+This is about connection multiplicity for throughput / NLB-IP / core spread.
+There is no 200-stream bottleneck on the tunnel client's paths: both the cloud
+ingress server and the tunnel client's `serve()` advertise
+`max_concurrent_streams = u32::MAX`, so a single connection already carries
+unlimited concurrent streams.
+
+## Knobs
+
+All defaults preserve current behavior exactly (no idle-connection regression
+for low-traffic deployments).
+
+| Option (kebab TOML) / env | Type | Default | Effect |
+|---|---|---|---|
+| `environment-proxy-connections` / `RESTATE_ENVIRONMENT_PROXY_CONNECTIONS` | NonZeroUsize | 6 | Outbound H2 connections to the cloud; applied to both the ingress (:8080) and admin (:9070) proxies |
+| `tunnel-server-connections` / `RESTATE_TUNNEL_SERVER_CONNECTIONS` | NonZeroUsize | 1 | Inbound tunnel connections opened to each resolved tunnel server |
+| `environment-proxy` / `RESTATE_ENVIRONMENT_PROXY` | bool | true | Renamed from `remote-proxy`; serde `alias = "remote-proxy"` keeps the old name working |
+
+`pools-per-tunnel` (existing, default 16) is unchanged.
+
+`environment-proxy-connections` applies to both the ingress and admin proxies for
+simplicity. Admin is control-plane / low-traffic, so 6 is already generous there;
+sizing it up together with ingress is wasteful but harmless. Split into two knobs
+only if a real asymmetry shows up.
+
+## Implementation
+
+### `options.rs`
+- Rename the toggle `remote_proxy` -> `environment_proxy`. In `OptionsShadow` it
+  MUST be `Option<bool>` with
+  `#[serde(alias = "remote-proxy", skip_serializing_if = "Option::is_none")]`,
+  mirroring the existing `auth_token` / `bearer-token` field. Resolve the `true`
+  default after `extract()` when building `Options` (`Options.environment_proxy:
+  bool`).
+
+  Why not a plain `bool`: a non-`Option` default is serialized by
+  `Serialized::defaults` under the renamed key `environment-proxy`, while the
+  operator's `RESTATE_REMOTE_PROXY` arrives as the aliased key `remote-proxy`.
+  Both then exist in the merged figment dict and serde rejects them as a duplicate
+  field, so `Options::load` fails closed on every operator-managed pod. Verified
+  against figment 0.10.19 / serde in this repo: plain-`bool` errors with
+  `duplicate field environment-proxy`; `Option<bool>` + `skip_serializing_if`
+  extracts cleanly. (The existing `RESTATE_REMOTE_PROXY` works today only because
+  the default key and the env key are the same string; the rename splits them.)
+- Add `environment_proxy_connections: NonZeroUsize` and
+  `tunnel_server_connections: NonZeroUsize` to both structs. These can stay
+  non-`Option` (like `pools_per_tunnel`): they have no aliased env key, so the
+  default key and the env key are identical and override in place - no collision.
+- `OptionsShadow::default()`: `environment_proxy: None`,
+  `environment_proxy_connections: 6`, `tunnel_server_connections: 1`.
+- Reject configurations that set both `environment-proxy` and `remote-proxy`
+  before serde extraction, with a friendly error matching the existing
+  `auth-token` / `bearer-token` migration guard. This includes the env/env case
+  (`RESTATE_ENVIRONMENT_PROXY` + `RESTATE_REMOTE_PROXY`) and mixed file/env
+  cases.
+
+### `main.rs` outbound (trivial)
+- Replace both `NonZeroUsize::new(6).unwrap()` literals (the ingress and admin
+  `round_robin_client` calls) with `options.environment_proxy_connections`.
+- Replace `options.remote_proxy` with `options.environment_proxy`.
+
+### `main.rs` inbound (the substantive change)
+Open `tunnel_server_connections` connections per resolved server instead of one.
+
+- Restructure the tracking map from
+  `HashMap<Uri, (CancellationToken, watch::Receiver<TunnelStatus>)>` to
+  `HashMap<Uri, ServerConnections>` where:
+  ```rust
+  struct ServerConnections {
+      token: CancellationToken,                       // per-server; cancels all N tasks
+      statuses: Vec<watch::Receiver<TunnelStatus>>,
+  }
+  ```
+  Update `HealthState.uris` to the same type.
+- The no-change fast path stays keyed on server URIs (compare keys + len).
+- For each new server:
+  - Build the local-service clients (`alpn_client`, `http2_client`) once and
+    wrap them so they are **shared** across the N connection tasks (e.g. `Arc`),
+    so local pools stay at `pools_per_tunnel` per server, not per connection.
+    `http1_client` is already shared. Note this means the N inbound connections
+    multiplex onto the same downstream pool set: it bounds connections *per local
+    destination* at `pools_per_tunnel` (it does **not** bound the number of
+    distinct destinations - each pool connects per-authority, so distinct local
+    pods are unbounded). For a hub fanning heavy concurrent traffic at a single
+    local service, raise `pools_per_tunnel` alongside `tunnel_server_connections`.
+  - Create one per-server `token = token.child_token()`.
+  - For `i in 0..tunnel_server_connections`: make a status channel and a
+    `token.child_token()`, build the `Handler` (clone of the shared clients),
+    and spawn `handle_tunnel_uri` with metrics scoped to `(authority, i)`.
+    Collect the receivers into `statuses`.
+- Teardown (`retain`): cancel the per-server `token` (cancels all N children)
+  and call `remove_tunnel(authority, tunnel_server_connections)`.
+
+### `metrics.rs`
+- Add a `connection` label (the index, as a string) to `opened`, `draining`, and
+  `connection_attempts`, so the N tasks per server no longer share a series.
+  Labeling the counter too costs the same cardinality as the gauges and keeps a
+  single flapping/reconnecting connection visible in attempts; aggregate with
+  `sum without (connection)` for a per-server view.
+- `tunnel(server, connection_index)` sets the label pair for all three; per-
+  connection `opened(bool)` / `draining(bool)` no longer clobber each other.
+- `remove_tunnel(server, count)` removes all three series for indices `0..count`.
+  Removing `connection_attempts` bounds cardinality for SRV churn at the cost of
+  resetting that counter if a removed server later reappears.
+- This is a breaking metric schema change: even at the default
+  `tunnel-server-connections = 1`, `opened`, `draining`, and
+  `connection_attempts` gain `connection="0"`. Release notes and any dashboards
+  or alerts should aggregate with `sum without (connection)` when they need the
+  old per-server view.
+- Add request-level metrics for performance diagnosis:
+  - `requests_total{server,connection,direction,status}` with
+    `direction = inbound|outbound` and `status = ok|error`;
+  - `request_duration_seconds{server,connection,direction}` with buckets
+    `[0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30]`;
+  - `requests_inflight{server,connection,direction}`;
+  - `local_handler_duration_seconds{instance}` with the same buckets;
+  - `local_handler_inflight{instance}`.
+
+  Request duration is measured until upstream response headers are received. The
+  local-handler metrics are measured from forwarding to the local handler until
+  response headers are received. Stream-level rejection reasons and RTT require
+  lower-level h2/hyper hooks and are follow-up work, not part of this PR.
+
+### health (`main.rs`)
+- Aggregate the N connection statuses per server with a deterministic precedence,
+  reporting the highest present: `Open > Opening > Draining > BackingOff >
+  Cancelled`. `HealthOutput` stays keyed by `Uri`.
+- `started` readiness latch is unchanged: any connection open anywhere -> started.
+
+## Inbound throughput: cloud-side behavior
+
+Confirmed in the cloud tunnel-server code: within a single tunnel-server process,
+each proxied request selects a ready live connection for the
+`(environment_id, tunnel_name)` at request time. So multiple connections landing
+on the same process are utilized. This is not a global cross-pod tunnel map; the
+benefit and evenness across cloud ingress pods still depend on NLB/request
+routing and where the connections terminate.
+
+The multi-pod-hub precedent is **not** a proof: those connections terminate on
+different ingress pods by construction, whereas N connections from one pod are not
+guaranteed to spread across ingress pods (the NLB hashes on source ip:port -
+distinct source ports can spread, but nothing guarantees distinct ingress pods),
+and the cloud still must choose among a tunnel's live connections when pushing.
+
+Sizing: total inbound connections = (number of resolved tunnel servers) x
+`tunnel_server_connections`. On a region that resolves to multiple tunnel IPs the
+default of 1 is already more than one connection.
+
+## Operator integration
+
+No restate-operator code change is required to use the two connection-count
+knobs: they pass through the rce's `tunnel.env` as
+`RESTATE_TUNNEL_SERVER_CONNECTIONS` /
+`RESTATE_ENVIRONMENT_PROXY_CONNECTIONS`. Surfacing a first-class operator field
+(e.g. `tunnelServerConnections` beside `replicas`) is a possible follow-up, out of
+scope here.
+
+The renamed proxy toggle is different. The current operator always emits
+`RESTATE_REMOTE_PROXY`, so operator-managed deployments should continue using
+that name for now. Adding `RESTATE_ENVIRONMENT_PROXY` via `tunnel.env` while the
+operator also emits `RESTATE_REMOTE_PROXY` is intentionally rejected by the
+dual-key guard. Actually switching to the new env var requires a coordinated
+operator change: upgrade tunnel-client images first so they understand
+`RESTATE_ENVIRONMENT_PROXY`, then change the operator to emit only the new name
+and never both names in the same pod.
+
+## Out of scope
+- `worker_threads`: `available_parallelism()` already honors the pod's cgroup CPU
+  limit. Revisit as an env-only knob if a real need appears.
+- The operator-side "sidecar tunnel" option (lives in restate-operator).
+
+## Testing
+- `options.rs` tests (these must run serially or with isolated env, since they set
+  process env vars):
+  - defaults resolve as expected (`environment_proxy = true`, connections 6 / 1);
+  - env override of each new knob;
+  - **regression for the collision**: with `RESTATE_REMOTE_PROXY=false` set,
+    `Options::load` succeeds and yields `environment_proxy = false` (this is the
+    case that fails with a plain `bool`);
+  - `RESTATE_ENVIRONMENT_PROXY=false` also works;
+  - setting both `environment-proxy` and `remote-proxy` fails with a friendly
+    error before serde reports a duplicate field.
+- Existing `parse_tunnel_destination` tests are unaffected.
+- Manual: with `tunnel_server_connections=N`, confirm N connections per server and
+  N `opened` series per server; with `environment_proxy_connections=M`, confirm M
+  outbound connections.

--- a/src/main.rs
+++ b/src/main.rs
@@ -136,15 +136,15 @@ pub async fn main() -> anyhow::Result<()> {
         authorization
     };
 
-    if options.remote_proxy {
+    if options.environment_proxy {
         {
             let router = axum::Router::new()
                 .fallback(remote_proxy)
                 .with_state(Arc::new(ProxyState {
                     base_uri: options.ingress_uri.clone(),
-                    // for calls to restate cloud, we use 6 conns so we have a fair spread over the 3 nlb ips
+                    server: authority_label(&options.ingress_uri),
                     client: round_robin_client(
-                        NonZeroUsize::new(6).unwrap(),
+                        options.environment_proxy_connections,
                         http2_builder,
                         &https_alpn_connector,
                     ),
@@ -171,9 +171,9 @@ pub async fn main() -> anyhow::Result<()> {
                 .fallback(remote_proxy)
                 .with_state(Arc::new(ProxyState {
                     base_uri: options.admin_uri.clone(),
-                    // for calls to restate cloud, we use 6 conns so we have a fair spread over the 3 nlb ips
+                    server: authority_label(&options.admin_uri),
                     client: round_robin_client(
-                        NonZeroUsize::new(6).unwrap(),
+                        options.environment_proxy_connections,
                         http2_builder,
                         &https_alpn_connector,
                     ),
@@ -195,7 +195,7 @@ pub async fn main() -> anyhow::Result<()> {
             tokio::spawn(connections.track_future(server.into_future()));
         };
     } else {
-        info!("Not proxying local ports to Restate Cloud as RESTATE_REMOTE_PROXY is false");
+        info!("Not proxying local ports to Restate Cloud as RESTATE_ENVIRONMENT_PROXY is false");
     }
 
     {
@@ -253,19 +253,27 @@ pub async fn main() -> anyhow::Result<()> {
                 continue;
             }
 
-            info!(%server, %server_name, "Starting new tunnel");
+            info!(
+                %server,
+                %server_name,
+                connections = options.tunnel_server_connections.get(),
+                "Starting new tunnel"
+            );
 
-            let (status_send, status_recv) = watch::channel(TunnelStatus::Opening);
-            let token = token.child_token();
+            let server_token = token.child_token();
+            let mut statuses = Vec::with_capacity(options.tunnel_server_connections.get());
 
-            let alpn_client = round_robin_client(
+            let alpn_client = Arc::new(round_robin_client(
                 options.pools_per_tunnel,
                 &http1_or_http2_builder,
                 &https_alpn_connector,
-            );
+            ));
             let http1_client = http1_client.clone();
-            let http2_client =
-                round_robin_client(options.pools_per_tunnel, http2_builder, &https_h2_connector);
+            let http2_client = Arc::new(round_robin_client(
+                options.pools_per_tunnel,
+                http2_builder,
+                &https_h2_connector,
+            ));
 
             let https_connector = hyper_rustls::HttpsConnectorBuilder::new()
                 .with_tls_config(TLS_CLIENT_CONFIG.clone())
@@ -276,36 +284,64 @@ pub async fn main() -> anyhow::Result<()> {
                 .enable_http2()
                 .wrap_connector(http_connector.clone());
 
-            let handler = Handler::<(), ()>::new(
-                hyper::service::service_fn(move |req| {
-                    local_proxy(&alpn_client, &http1_client, &http2_client, req)
-                }),
-                &options.environment_id,
-                &options.signing_public_key,
-                &options.auth_token,
-                Some(options.tunnel_name.clone()),
-                Option::<fn(_)>::None,
-            )
-            .expect("failed to create tunnel handler");
+            for connection_index in 0..options.tunnel_server_connections.get() {
+                let (status_send, status_recv) = watch::channel(TunnelStatus::Opening);
+                let connection_token = server_token.child_token();
+                let alpn_client = alpn_client.clone();
+                let http1_client = http1_client.clone();
+                let http2_client = http2_client.clone();
 
-            let tunnel_metrics =
-                METRICS.tunnel(server.authority().map(|a| a.as_str()).unwrap_or_default());
+                let tunnel_metrics = METRICS.tunnel(
+                    server.authority().map(|a| a.as_str()).unwrap_or_default(),
+                    connection_index,
+                );
+                let request_metrics = tunnel_metrics.clone();
 
-            let fut = handle_tunnel_uri(
-                handler,
-                https_connector,
-                token.clone(),
-                status_send,
+                let handler = Handler::<(), ()>::new(
+                    hyper::service::service_fn(move |req| {
+                        local_proxy(
+                            &alpn_client,
+                            &http1_client,
+                            &http2_client,
+                            request_metrics.clone(),
+                            req,
+                        )
+                    }),
+                    &options.environment_id,
+                    &options.signing_public_key,
+                    &options.auth_token,
+                    Some(options.tunnel_name.clone()),
+                    Option::<fn(_)>::None,
+                )
+                .expect("failed to create tunnel handler");
+
+                let fut = handle_tunnel_uri(
+                    handler,
+                    https_connector.clone(),
+                    connection_token,
+                    status_send,
+                    server.clone(),
+                    tunnel_metrics,
+                )
+                .instrument(
+                    info_span!("tunnel", %server, %server_name, connection = connection_index)
+                        .or_current(),
+                );
+
+                tokio::spawn(connections.track_future(fut));
+                statuses.push(status_recv);
+            }
+
+            uris.insert(
                 server.clone(),
-                tunnel_metrics,
-            )
-            .instrument(info_span!("tunnel", %server, %server_name).or_current());
-
-            tokio::spawn(connections.track_future(fut));
-            uris.insert(server.clone(), (token, status_recv));
+                ServerConnections {
+                    token: server_token,
+                    statuses,
+                },
+            );
         }
 
-        uris.retain(|existing_uri, (token, _)| {
+        uris.retain(|existing_uri, connections| {
             if !tunnel_servers.contains_key(existing_uri) {
                 info!(server = %existing_uri, "Tearing down tunnel");
                 METRICS.remove_tunnel(
@@ -313,8 +349,9 @@ pub async fn main() -> anyhow::Result<()> {
                         .authority()
                         .map(|a| a.as_str())
                         .unwrap_or_default(),
+                    connections.statuses.len(),
                 );
-                token.cancel();
+                connections.token.cancel();
                 false
             } else {
                 true
@@ -338,9 +375,13 @@ pub async fn main() -> anyhow::Result<()> {
 
 #[derive(Clone)]
 struct HealthState {
-    #[allow(clippy::type_complexity)]
-    uris: Arc<RwLock<HashMap<Uri, (CancellationToken, watch::Receiver<TunnelStatus>)>>>,
+    uris: Arc<RwLock<HashMap<Uri, ServerConnections>>>,
     started: Arc<AtomicBool>,
+}
+
+struct ServerConnections {
+    token: CancellationToken,
+    statuses: Vec<watch::Receiver<TunnelStatus>>,
 }
 
 #[serde_with::serde_as]
@@ -356,8 +397,8 @@ async fn health(
         Ok(uris) => {
             let mut statuses = HashMap::new();
             let mut one_open = false;
-            for (uri, (_, receiver)) in uris.iter() {
-                let status = *receiver.borrow();
+            for (uri, connections) in uris.iter() {
+                let status = aggregate_tunnel_status(&connections.statuses);
                 statuses.insert(uri.clone(), status);
                 if matches!(status, TunnelStatus::Open) {
                     one_open = true
@@ -369,7 +410,7 @@ async fn health(
                 true
             } else {
                 // once we have started, we don't want to stop being ready because the tunnel servers are down
-                // otherwise our endpoints will stop getting published and we could break remote proxy outbound calls
+                // otherwise our endpoints will stop getting published and we could break environment proxy outbound calls
                 state.started.load(Ordering::Relaxed)
             };
 
@@ -389,6 +430,32 @@ async fn health(
     }
 }
 
+fn aggregate_tunnel_status(statuses: &[watch::Receiver<TunnelStatus>]) -> TunnelStatus {
+    let mut saw_opening = false;
+    let mut saw_draining = false;
+    let mut saw_backing_off = false;
+
+    for receiver in statuses {
+        match *receiver.borrow() {
+            TunnelStatus::Open => return TunnelStatus::Open,
+            TunnelStatus::Opening => saw_opening = true,
+            TunnelStatus::Draining => saw_draining = true,
+            TunnelStatus::BackingOff => saw_backing_off = true,
+            TunnelStatus::Cancelled => {}
+        }
+    }
+
+    if saw_opening {
+        TunnelStatus::Opening
+    } else if saw_draining {
+        TunnelStatus::Draining
+    } else if saw_backing_off {
+        TunnelStatus::BackingOff
+    } else {
+        TunnelStatus::Cancelled
+    }
+}
+
 async fn metrics_endpoint() -> impl IntoResponse {
     (
         [(http::header::CONTENT_TYPE, "text/plain; version=0.0.4")],
@@ -398,6 +465,7 @@ async fn metrics_endpoint() -> impl IntoResponse {
 
 struct ProxyState {
     base_uri: Uri,
+    server: String,
     client: RoundRobinClient<axum::body::Body>,
     authorization: http::HeaderValue,
 }
@@ -431,10 +499,16 @@ async fn remote_proxy(
     let span = debug_span!("remote_request", destination = %req.uri());
 
     async {
-        let result = match state.client.get().request(req).await {
+        let (client, connection_index) = state.client.get();
+        let connection_index = connection_index.to_string();
+        let request_metrics = METRICS.request(&state.server, &connection_index, "outbound");
+        let request_guard = request_metrics.start();
+
+        let result = match client.request(req).await {
             Ok(result) => result,
             Err(err) => {
                 debug!(%err, "Failed to proxy request to Restate Cloud");
+                request_guard.finish(false);
                 METRICS.record_remote_proxy_request(false);
 
                 return http::Response::builder()
@@ -444,6 +518,7 @@ async fn remote_proxy(
             }
         };
 
+        request_guard.finish(true);
         METRICS.record_remote_proxy_request(true);
         debug!(
             status = result.status().as_u16(),
@@ -492,6 +567,7 @@ fn remote_proxy_headers(headers: &mut http::HeaderMap, authorization: http::Head
 enum TunnelStatus {
     Opening,
     Open,
+    Draining,
     BackingOff,
     Cancelled,
 }
@@ -565,11 +641,12 @@ async fn handle_tunnel_uri<Notify, Client, ClientError, ClientFuture, ResponseBo
             }
         });
         // we treat the tunnel as opened 5s after the connection is open, as the handshake timeout is 5s
-        let mut opened_after = std::pin::pin!(
-            connected_rx
-                .and_then(|_| async { Ok(tokio::time::sleep(Duration::from_secs(5)).await) })
-        );
+        let mut opened_after = std::pin::pin!(connected_rx.and_then(|_| async {
+            tokio::time::sleep(Duration::from_secs(5)).await;
+            Ok(())
+        }));
         let mut opened = false;
+        let mut draining = false;
 
         loop {
             tokio::select! {
@@ -595,6 +672,8 @@ async fn handle_tunnel_uri<Notify, Client, ClientError, ClientFuture, ResponseBo
                     break
                 }
                 _ = on_drain.cancelled() => {
+                    let _ = status.send(TunnelStatus::Draining);
+                    draining = true;
                     metrics.draining(true);
                     let metrics = metrics.clone();
                     tokio::task::spawn(async move {
@@ -631,7 +710,11 @@ async fn handle_tunnel_uri<Notify, Client, ClientError, ClientFuture, ResponseBo
         }
 
         metrics.opened(false);
-        let _ = status.send(TunnelStatus::BackingOff);
+        let _ = status.send(if draining {
+            TunnelStatus::Draining
+        } else {
+            TunnelStatus::BackingOff
+        });
 
         tokio::select! {
             _ = token.cancelled() => {
@@ -681,9 +764,15 @@ impl<B> RoundRobinClient<B> {
         }
     }
 
-    fn get(&self) -> &hyper_util::client::legacy::Client<HttpsConnector<HttpConnector>, B> {
+    fn get(
+        &self,
+    ) -> (
+        &hyper_util::client::legacy::Client<HttpsConnector<HttpConnector>, B>,
+        usize,
+    ) {
         let i = self.index.fetch_add(1, Ordering::Relaxed);
-        &self.clients[i % self.clients.len()]
+        let connection_index = i % self.clients.len();
+        (&self.clients[connection_index], connection_index)
     }
 }
 
@@ -691,6 +780,7 @@ fn local_proxy(
     alpn_client: &RoundRobinClient<Incoming>,
     http1_client: &hyper_util::client::legacy::Client<HttpsConnector<HttpConnector>, Incoming>,
     http2_client: &RoundRobinClient<Incoming>,
+    metrics: TunnelMetrics,
     req: http::Request<Incoming>,
 ) -> impl Future<
     Output = Result<
@@ -706,10 +796,12 @@ fn local_proxy(
 >
 + 'static
 + use<> {
+    let request_guard = metrics.start_request();
     let (mut head, body) = req.into_parts();
 
     let Some(path_and_query) = head.uri.path_and_query() else {
         warn!(uri = %head.uri, "Tunnel request was missing path");
+        request_guard.finish(false);
         return std::future::ready(Ok(http::Response::builder()
             .status(StatusCode::BAD_REQUEST)
             .body(http_body_util::Either::Left(http_body_util::Empty::new()))
@@ -721,6 +813,7 @@ fn local_proxy(
         Ok(destination) => destination,
         Err(message) => {
             warn!(uri = %head.uri, "Tunnel request had an invalid path ({})", message);
+            request_guard.finish(false);
             return std::future::ready(Ok(http::Response::builder()
                 .status(StatusCode::BAD_REQUEST)
                 .body(http_body_util::Either::Left(http_body_util::Empty::new()))
@@ -730,6 +823,7 @@ fn local_proxy(
     };
 
     head.uri = destination;
+    let instance = authority_label(&head.uri);
 
     let client = match (
         head.uri.scheme_str(),
@@ -742,18 +836,18 @@ fn local_proxy(
             // we don't want to force HTTP2 as we don't know if the destination accepts it
             // a request with HTTP_11 can still end up using h2 if the alpn agrees
             head.version = http::Version::HTTP_11;
-            alpn_client.get()
+            alpn_client.get().0
         }
         // cleartext requests where the user didn't request a specific version; use http2 prior-knowledge
         (_, None) => {
             head.version = http::Version::HTTP_2;
-            http2_client.get()
+            http2_client.get().0
         }
         // https or cleartext requests where the user requested http2; use http2
         // prior-knowledge for cleartext, h2 in alpn otherwise
         (_, Some(b"HTTP/2.0")) => {
             head.version = http::Version::HTTP_2;
-            http2_client.get()
+            http2_client.get().0
         }
         // https or cleartext requests where the user requested http1.1; use http1.1
         // will not use h2 even if the alpn supports it
@@ -763,6 +857,7 @@ fn local_proxy(
         }
         (_, Some(other)) => {
             warn!(uri = %head.uri, "Tunnel request had an invalid x-restate-tunnel-http-version ({})", String::from_utf8_lossy(other));
+            request_guard.finish(false);
             return std::future::ready(Ok(http::Response::builder()
                 .status(StatusCode::BAD_REQUEST)
                 .body(http_body_util::Either::Left(http_body_util::Empty::new()))
@@ -775,11 +870,15 @@ fn local_proxy(
 
     let span = debug_span!("local_request", destination = %req.uri());
 
+    let local_handler_metrics = METRICS.local_handler(&instance);
     let fut = client.request(req);
 
     async move {
+        let local_handler_guard = local_handler_metrics.start();
         match fut.await {
             Ok(response) => {
+                local_handler_guard.finish();
+                request_guard.finish(true);
                 METRICS.record_local_proxy_request(true);
                 debug!(
                     status = response.status().as_u16(),
@@ -788,6 +887,8 @@ fn local_proxy(
                 Ok(response.map(http_body_util::Either::Right))
             }
             Err(err) => {
+                local_handler_guard.finish();
+                request_guard.finish(false);
                 METRICS.record_local_proxy_request(false);
                 error!(%err, "Failed to proxy request from Restate Cloud");
 
@@ -800,6 +901,12 @@ fn local_proxy(
     }
     .instrument(span)
     .right_future()
+}
+
+fn authority_label(uri: &Uri) -> String {
+    uri.authority()
+        .map(|authority| authority.as_str().to_owned())
+        .unwrap_or_default()
 }
 
 fn parse_tunnel_destination(path_and_query: &http::uri::PathAndQuery) -> Result<Uri, &'static str> {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,14 +1,27 @@
 use prometheus::{
-    Encoder, IntCounterVec, IntGaugeVec, Opts, Registry, TextEncoder,
+    Encoder, Histogram, HistogramOpts, HistogramVec, IntCounterVec, IntGaugeVec, Opts, Registry,
+    TextEncoder,
     core::{AtomicI64, AtomicU64, GenericCounter, GenericGauge},
 };
-use std::sync::LazyLock;
+use std::{
+    sync::LazyLock,
+    time::{Duration, Instant},
+};
+
+const REQUEST_DURATION_BUCKETS: &[f64] = &[
+    0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0,
+];
 
 pub struct Metrics {
     registry: Registry,
     opened: IntGaugeVec,
     draining: IntGaugeVec,
     connection_attempts: IntCounterVec,
+    requests: IntCounterVec,
+    request_duration: HistogramVec,
+    requests_inflight: IntGaugeVec,
+    local_handler_duration: HistogramVec,
+    local_handler_inflight: IntGaugeVec,
     local_proxy_requests: IntCounterVec,
     remote_proxy_requests: IntCounterVec,
 }
@@ -19,6 +32,7 @@ pub struct TunnelMetrics {
     opened: GenericGauge<AtomicI64>,
     draining: GenericGauge<AtomicI64>,
     connection_attempts: GenericCounter<AtomicU64>,
+    request_metrics: RequestMetrics,
 }
 
 impl TunnelMetrics {
@@ -33,6 +47,115 @@ impl TunnelMetrics {
     pub fn inc_connection_attempts(&self) {
         self.connection_attempts.inc();
     }
+
+    pub fn start_request(&self) -> RequestGuard {
+        self.request_metrics.start()
+    }
+}
+
+#[derive(Clone)]
+pub struct RequestMetrics {
+    inflight: GenericGauge<AtomicI64>,
+    duration: Histogram,
+    ok: GenericCounter<AtomicU64>,
+    error: GenericCounter<AtomicU64>,
+}
+
+impl RequestMetrics {
+    pub fn start(&self) -> RequestGuard {
+        self.inflight.inc();
+        RequestGuard {
+            inflight: self.inflight.clone(),
+            duration: self.duration.clone(),
+            ok: self.ok.clone(),
+            error: self.error.clone(),
+            start: Instant::now(),
+            finished: false,
+        }
+    }
+}
+
+pub struct RequestGuard {
+    inflight: GenericGauge<AtomicI64>,
+    duration: Histogram,
+    ok: GenericCounter<AtomicU64>,
+    error: GenericCounter<AtomicU64>,
+    start: Instant,
+    finished: bool,
+}
+
+impl RequestGuard {
+    pub fn finish(mut self, success: bool) {
+        self.observe(success);
+    }
+
+    fn observe(&mut self, success: bool) {
+        if self.finished {
+            return;
+        }
+
+        self.duration.observe(elapsed_seconds(self.start.elapsed()));
+        if success {
+            self.ok.inc();
+        } else {
+            self.error.inc();
+        }
+        self.inflight.dec();
+        self.finished = true;
+    }
+}
+
+impl Drop for RequestGuard {
+    fn drop(&mut self) {
+        if !self.finished {
+            self.inflight.dec();
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct LocalHandlerMetrics {
+    inflight: GenericGauge<AtomicI64>,
+    duration: Histogram,
+}
+
+impl LocalHandlerMetrics {
+    pub fn start(&self) -> LocalHandlerGuard {
+        self.inflight.inc();
+        LocalHandlerGuard {
+            inflight: self.inflight.clone(),
+            duration: self.duration.clone(),
+            start: Instant::now(),
+            finished: false,
+        }
+    }
+}
+
+pub struct LocalHandlerGuard {
+    inflight: GenericGauge<AtomicI64>,
+    duration: Histogram,
+    start: Instant,
+    finished: bool,
+}
+
+impl LocalHandlerGuard {
+    pub fn finish(mut self) {
+        if self.finished {
+            return;
+        }
+
+        self.duration.observe(elapsed_seconds(self.start.elapsed()));
+        self.inflight.dec();
+        self.finished = true;
+    }
+}
+
+impl Drop for LocalHandlerGuard {
+    fn drop(&mut self) {
+        if !self.finished {
+            self.inflight.dec();
+        }
+    }
 }
 
 impl Metrics {
@@ -45,7 +168,7 @@ impl Metrics {
                 "Whether the tunnel is currently open (1) or not (0)",
             )
             .namespace("restate_cloud_tunnel"),
-            &["server"],
+            &["server", "connection"],
         )
         .expect("metric can be created");
         registry
@@ -58,7 +181,7 @@ impl Metrics {
                 "Whether the tunnel is currently draining (1) or not (0)",
             )
             .namespace("restate_cloud_tunnel"),
-            &["server"],
+            &["server", "connection"],
         )
         .expect("metric can be created");
         registry
@@ -71,11 +194,78 @@ impl Metrics {
                 "Total number of tunnel connection attempts",
             )
             .namespace("restate_cloud_tunnel"),
-            &["server"],
+            &["server", "connection"],
         )
         .expect("metric can be created");
         registry
             .register(Box::new(connection_attempts.clone()))
+            .expect("metric can be registered");
+
+        let requests = IntCounterVec::new(
+            Opts::new(
+                "requests_total",
+                "Total requests proxied by the tunnel client",
+            )
+            .namespace("restate_cloud_tunnel"),
+            &["server", "connection", "direction", "status"],
+        )
+        .expect("metric can be created");
+        registry
+            .register(Box::new(requests.clone()))
+            .expect("metric can be registered");
+
+        let request_duration = HistogramVec::new(
+            HistogramOpts::new(
+                "request_duration_seconds",
+                "Time from tunnel-client request handling to upstream response headers",
+            )
+            .namespace("restate_cloud_tunnel")
+            .buckets(REQUEST_DURATION_BUCKETS.to_vec()),
+            &["server", "connection", "direction"],
+        )
+        .expect("metric can be created");
+        registry
+            .register(Box::new(request_duration.clone()))
+            .expect("metric can be registered");
+
+        let requests_inflight = IntGaugeVec::new(
+            Opts::new(
+                "requests_inflight",
+                "Requests currently being handled by the tunnel client",
+            )
+            .namespace("restate_cloud_tunnel"),
+            &["server", "connection", "direction"],
+        )
+        .expect("metric can be created");
+        registry
+            .register(Box::new(requests_inflight.clone()))
+            .expect("metric can be registered");
+
+        let local_handler_duration = HistogramVec::new(
+            HistogramOpts::new(
+                "local_handler_duration_seconds",
+                "Time from forwarding to a local handler until response headers are received",
+            )
+            .namespace("restate_cloud_tunnel")
+            .buckets(REQUEST_DURATION_BUCKETS.to_vec()),
+            &["instance"],
+        )
+        .expect("metric can be created");
+        registry
+            .register(Box::new(local_handler_duration.clone()))
+            .expect("metric can be registered");
+
+        let local_handler_inflight = IntGaugeVec::new(
+            Opts::new(
+                "local_handler_inflight",
+                "Requests currently waiting on a local handler response",
+            )
+            .namespace("restate_cloud_tunnel"),
+            &["instance"],
+        )
+        .expect("metric can be created");
+        registry
+            .register(Box::new(local_handler_inflight.clone()))
             .expect("metric can be registered");
 
         let local_proxy_requests = IntCounterVec::new(
@@ -109,6 +299,11 @@ impl Metrics {
             opened,
             draining,
             connection_attempts,
+            requests,
+            request_duration,
+            requests_inflight,
+            local_handler_duration,
+            local_handler_inflight,
             local_proxy_requests,
             remote_proxy_requests,
         }
@@ -126,19 +321,61 @@ impl Metrics {
     }
 
     /// Create metrics scoped to a particular tunnel server
-    pub fn tunnel(&self, server: &str) -> TunnelMetrics {
+    pub fn tunnel(&self, server: &str, connection_index: usize) -> TunnelMetrics {
+        let connection_index = connection_index.to_string();
+
         TunnelMetrics {
-            opened: self.opened.with_label_values(&[server]),
-            draining: self.draining.with_label_values(&[server]),
-            connection_attempts: self.connection_attempts.with_label_values(&[server]),
+            opened: self
+                .opened
+                .with_label_values(&[server, connection_index.as_str()]),
+            draining: self
+                .draining
+                .with_label_values(&[server, connection_index.as_str()]),
+            connection_attempts: self
+                .connection_attempts
+                .with_label_values(&[server, connection_index.as_str()]),
+            request_metrics: self.request(server, connection_index.as_str(), "inbound"),
         }
     }
 
-    pub fn remove_tunnel(&self, server: &str) {
-        let _ = self.opened.remove_label_values(&[server]);
-        let _ = self.draining.remove_label_values(&[server]);
-        // we keep labels in connection_attempts as it is a counter, this is a theoretical cardinality issue
-        // but in practice tunnel server ips do not change much
+    pub fn request(&self, server: &str, connection: &str, direction: &str) -> RequestMetrics {
+        RequestMetrics {
+            inflight: self
+                .requests_inflight
+                .with_label_values(&[server, connection, direction]),
+            duration: self
+                .request_duration
+                .with_label_values(&[server, connection, direction]),
+            ok: self
+                .requests
+                .with_label_values(&[server, connection, direction, "ok"]),
+            error: self
+                .requests
+                .with_label_values(&[server, connection, direction, "error"]),
+        }
+    }
+
+    pub fn local_handler(&self, instance: &str) -> LocalHandlerMetrics {
+        LocalHandlerMetrics {
+            inflight: self.local_handler_inflight.with_label_values(&[instance]),
+            duration: self.local_handler_duration.with_label_values(&[instance]),
+        }
+    }
+
+    pub fn remove_tunnel(&self, server: &str, count: usize) {
+        for connection_index in 0..count {
+            let connection_index = connection_index.to_string();
+            let labels = [server, connection_index.as_str()];
+
+            let _ = self.opened.remove_label_values(&labels);
+            let _ = self.draining.remove_label_values(&labels);
+            let _ = self.connection_attempts.remove_label_values(&labels);
+            let _ = self.requests_inflight.remove_label_values(&[
+                server,
+                connection_index.as_str(),
+                "inbound",
+            ]);
+        }
     }
 
     pub fn record_local_proxy_request(&self, success: bool) {
@@ -155,3 +392,7 @@ impl Metrics {
 }
 
 pub static METRICS: LazyLock<Metrics> = LazyLock::new(Metrics::new);
+
+fn elapsed_seconds(duration: Duration) -> f64 {
+    duration.as_secs_f64()
+}

--- a/src/options.rs
+++ b/src/options.rs
@@ -43,7 +43,10 @@ struct OptionsShadow {
     shutdown_timeout: Duration,
     health_serve_address: SocketAddr,
 
-    remote_proxy: bool,
+    #[serde(alias = "remote-proxy", skip_serializing_if = "Option::is_none")]
+    environment_proxy: Option<bool>,
+    environment_proxy_connections: NonZeroUsize,
+    tunnel_server_connections: NonZeroUsize,
     ingress_serve_address: SocketAddr,
     admin_serve_address: SocketAddr,
 
@@ -72,7 +75,10 @@ impl Default for OptionsShadow {
             initial_max_send_streams: None,
             http_keep_alive_options: Http2KeepAliveOptions::default(),
             shutdown_timeout: Duration::from_secs(300),
-            remote_proxy: true,
+            environment_proxy: None,
+            // Preserve the previous hard-coded fan-out for spreading over cloud NLB IPs.
+            environment_proxy_connections: NonZeroUsize::new(6).unwrap(),
+            tunnel_server_connections: NonZeroUsize::new(1).unwrap(),
             health_serve_address: SocketAddr::V6(SocketAddrV6::new(
                 Ipv6Addr::UNSPECIFIED,
                 9090,
@@ -115,7 +121,9 @@ pub struct Options {
     pub shutdown_timeout: Duration,
     pub health_serve_address: SocketAddr,
 
-    pub remote_proxy: bool,
+    pub environment_proxy: bool,
+    pub environment_proxy_connections: NonZeroUsize,
+    pub tunnel_server_connections: NonZeroUsize,
 
     pub ingress_serve_address: SocketAddr,
     pub ingress_uri: Uri,
@@ -145,12 +153,25 @@ impl Options {
                 "Both RESTATE_AUTH_TOKEN_FILE and RESTATE_BEARER_TOKEN_FILE are set; unset RESTATE_BEARER_TOKEN_FILE (deprecated alias for RESTATE_AUTH_TOKEN_FILE)"
             );
         }
+        if std::env::var_os("RESTATE_ENVIRONMENT_PROXY").is_some()
+            && std::env::var_os("RESTATE_REMOTE_PROXY").is_some()
+        {
+            bail!(
+                "Both RESTATE_ENVIRONMENT_PROXY and RESTATE_REMOTE_PROXY are set; unset RESTATE_REMOTE_PROXY (deprecated alias for RESTATE_ENVIRONMENT_PROXY)"
+            );
+        }
 
         figment = figment.merge(
             Env::prefixed("RESTATE_")
                 .split("__")
                 .map(|k| k.as_str().replace('_', "-").into()),
         );
+
+        if figment.contains("environment-proxy") && figment.contains("remote-proxy") {
+            bail!(
+                "Both 'environment-proxy' and 'remote-proxy' are set; unset 'remote-proxy' (deprecated alias for 'environment-proxy')"
+            );
+        }
 
         let shadow: OptionsShadow = figment.extract()?;
 
@@ -292,11 +313,225 @@ impl Options {
             http_keep_alive_options: shadow.http_keep_alive_options,
             shutdown_timeout: shadow.shutdown_timeout,
             health_serve_address: shadow.health_serve_address,
-            remote_proxy: shadow.remote_proxy,
+            environment_proxy: shadow.environment_proxy.unwrap_or(true),
+            environment_proxy_connections: shadow.environment_proxy_connections,
+            tunnel_server_connections: shadow.tunnel_server_connections,
             ingress_serve_address: shadow.ingress_serve_address,
             ingress_uri,
             admin_serve_address: shadow.admin_serve_address,
             admin_uri,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        env,
+        ffi::OsString,
+        sync::{Mutex, MutexGuard},
+    };
+
+    use super::*;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    const TEST_ENV_KEYS: &[&str] = &[
+        "RESTATE_ADMIN_URI",
+        "RESTATE_AUTH_TOKEN",
+        "RESTATE_AUTH_TOKEN_FILE",
+        "RESTATE_BEARER_TOKEN",
+        "RESTATE_BEARER_TOKEN_FILE",
+        "RESTATE_CLOUD_REGION",
+        "RESTATE_ENVIRONMENT_PROXY",
+        "RESTATE_ENVIRONMENT_PROXY_CONNECTIONS",
+        "RESTATE_INGRESS_URI",
+        "RESTATE_REMOTE_PROXY",
+        "RESTATE_SIGNING_PUBLIC_KEY",
+        "RESTATE_TUNNEL_NAME",
+        "RESTATE_TUNNEL_SERVERS",
+        "RESTATE_TUNNEL_SERVERS_SRV",
+        "RESTATE_TUNNEL_SERVER_CONNECTIONS",
+    ];
+
+    struct EnvGuard {
+        saved: Vec<(&'static str, Option<OsString>)>,
+        _lock: MutexGuard<'static, ()>,
+    }
+
+    impl EnvGuard {
+        fn new() -> Self {
+            let lock = ENV_LOCK
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            let saved = TEST_ENV_KEYS
+                .iter()
+                .map(|key| (*key, env::var_os(key)))
+                .collect();
+
+            for key in TEST_ENV_KEYS {
+                unsafe {
+                    env::remove_var(key);
+                }
+            }
+
+            Self { saved, _lock: lock }
+        }
+
+        fn set(&self, key: &str, value: &str) {
+            unsafe {
+                env::set_var(key, value);
+            }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            for (key, value) in &self.saved {
+                unsafe {
+                    if let Some(value) = value {
+                        env::set_var(key, value);
+                    } else {
+                        env::remove_var(key);
+                    }
+                }
+            }
+        }
+    }
+
+    fn load_options_from_toml_with_extra(extra_toml: &str) -> anyhow::Result<Options> {
+        let path = env::temp_dir().join(format!(
+            "restate-cloud-tunnel-client-options-{}.toml",
+            std::process::id()
+        ));
+
+        std::fs::write(
+            &path,
+            format!(
+                r#"
+environment-id = "env_test"
+signing-public-key = "test-signing-public-key"
+tunnel-name = "test-tunnel"
+tunnel-servers = ["https://127.0.0.1:19080/"]
+auth-token = "test-auth-token"
+ingress-uri = "https://ingress.example.com:8080/"
+admin-uri = "https://admin.example.com:9070/"
+{extra_toml}
+"#,
+            ),
+        )
+        .unwrap();
+
+        let options = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(Options::load(&path));
+
+        let _ = std::fs::remove_file(path);
+
+        options
+    }
+
+    fn load_options_from_toml() -> Options {
+        load_options_from_toml_with_extra("").unwrap()
+    }
+
+    fn extract_shadow_from_env() -> OptionsShadow {
+        Figment::from(Serialized::defaults(OptionsShadow::default()))
+            .merge(
+                Env::prefixed("RESTATE_")
+                    .split("__")
+                    .map(|k| k.as_str().replace('_', "-").into()),
+            )
+            .extract()
+            .unwrap()
+    }
+
+    #[test]
+    fn defaults_connection_tuning_knobs() {
+        let _env_guard = EnvGuard::new();
+        let defaults = load_options_from_toml();
+
+        assert!(defaults.environment_proxy);
+        assert_eq!(defaults.environment_proxy_connections.get(), 6);
+        assert_eq!(defaults.tunnel_server_connections.get(), 1);
+    }
+
+    #[test]
+    fn env_overrides_connection_tuning_knobs() {
+        let env_guard = EnvGuard::new();
+        env_guard.set("RESTATE_ENVIRONMENT_PROXY", "false");
+        env_guard.set("RESTATE_ENVIRONMENT_PROXY_CONNECTIONS", "9");
+        env_guard.set("RESTATE_TUNNEL_SERVER_CONNECTIONS", "3");
+
+        let options = load_options_from_toml();
+
+        assert!(!options.environment_proxy);
+        assert_eq!(options.environment_proxy_connections.get(), 9);
+        assert_eq!(options.tunnel_server_connections.get(), 3);
+    }
+
+    #[test]
+    fn remote_proxy_env_alias_loads_without_collision() {
+        let env_guard = EnvGuard::new();
+        env_guard.set("RESTATE_REMOTE_PROXY", "false");
+
+        let options = load_options_from_toml();
+
+        assert!(!options.environment_proxy);
+    }
+
+    #[test]
+    fn environment_proxy_env_sets_environment_proxy() {
+        let env_guard = EnvGuard::new();
+        env_guard.set("RESTATE_ENVIRONMENT_PROXY", "false");
+
+        let options = load_options_from_toml();
+
+        assert!(!options.environment_proxy);
+    }
+
+    #[test]
+    fn environment_proxy_and_remote_proxy_envs_fail_with_helpful_error() {
+        let env_guard = EnvGuard::new();
+        env_guard.set("RESTATE_ENVIRONMENT_PROXY", "true");
+        env_guard.set("RESTATE_REMOTE_PROXY", "false");
+
+        let error = match load_options_from_toml_with_extra("") {
+            Ok(_) => panic!("expected environment proxy aliases to fail"),
+            Err(error) => error,
+        };
+
+        assert!(
+            error
+                .to_string()
+                .contains("Both RESTATE_ENVIRONMENT_PROXY and RESTATE_REMOTE_PROXY are set")
+        );
+    }
+
+    #[test]
+    fn environment_proxy_and_remote_proxy_sources_fail_with_helpful_error() {
+        let env_guard = EnvGuard::new();
+        env_guard.set("RESTATE_ENVIRONMENT_PROXY", "true");
+
+        let error = match load_options_from_toml_with_extra("remote-proxy = false") {
+            Ok(_) => panic!("expected environment proxy aliases to fail"),
+            Err(error) => error,
+        };
+
+        assert!(
+            error
+                .to_string()
+                .contains("Both 'environment-proxy' and 'remote-proxy' are set")
+        );
+    }
+
+    #[test]
+    fn shadow_defaults_do_not_serialize_environment_proxy() {
+        let _env_guard = EnvGuard::new();
+        let shadow = extract_shadow_from_env();
+
+        assert_eq!(shadow.environment_proxy, None);
     }
 }


### PR DESCRIPTION
## Summary
- expose `environment-proxy-connections` and `tunnel-server-connections` with defaults preserving current behavior
- keep `RESTATE_REMOTE_PROXY` compatibility while resolving the `environment-proxy` default after extraction to avoid Figment alias collisions
- reject dual `environment-proxy` / `remote-proxy` configuration with a friendly error before serde duplicate-field extraction
- fan out inbound tunnel connections per resolved server, with shared local-service pools, per-connection metrics, and aggregated health
- add request-level Prometheus metrics for proxied request throughput, response-header latency, and in-flight concurrency

## Compatibility notes
- `opened`, `draining`, and `connection_attempts` now include a `connection` label even at the default `tunnel-server-connections=1`; aggregate with `sum without (connection)` for the old per-server view
- older binaries ignore `RESTATE_ENVIRONMENT_PROXY`, so keep using `RESTATE_REMOTE_PROXY` until the rollback floor has passed
- current operator-managed deployments should also keep using `RESTATE_REMOTE_PROXY`; the operator emits that env var today, and emitting both names makes new tunnel-client pods reject the config
- the operator migration to `RESTATE_ENVIRONMENT_PROXY` must be a hard cutover after the image supports the new name, and must never emit both names in one pod
- the health JSON body can now report `Draining`, while the readiness status-code behavior is unchanged

## Request metrics
- `restate_cloud_tunnel_requests_total{server,connection,direction,status}`
- `restate_cloud_tunnel_request_duration_seconds{server,connection,direction}`
- `restate_cloud_tunnel_requests_inflight{server,connection,direction}`
- `restate_cloud_tunnel_local_handler_duration_seconds{instance}`
- `restate_cloud_tunnel_local_handler_inflight{instance}`

Durations are measured until upstream response headers are received. Stream rejection reasons and RTT need lower-level h2/hyper hooks and are left as follow-up work.

## Verification
- cargo fmt
- env -u RUSTC_WRAPPER cargo test
- env -u RUSTC_WRAPPER cargo check
- env -u RUSTC_WRAPPER cargo clippy

## Notes
Cloud tunnel-server code chooses a ready tunnel connection per request within each tunnel-server process. It does not provide a global cross-pod tunnel map.

I also checked local operator/cloud monitoring sources for client-side `restate_cloud_tunnel_opened`, `restate_cloud_tunnel_draining`, or `restate_cloud_tunnel_connection_attempts` consumers and did not find bundled rules or dashboards to update.